### PR TITLE
Add name label to power supplier prometheus metric

### DIFF
--- a/src/accessories/outlet.ts
+++ b/src/accessories/outlet.ts
@@ -15,6 +15,12 @@ const singleConsumption = new client.Gauge({
   labelNames: ['plug_name'],
 });
 
+const plugStatus = new client.Gauge({
+  name: 'comelit_plug_status',
+  help: 'Status of a single line (0 or 1)',
+  labelNames: ['plug_name'],
+});
+
 export class Outlet extends ComelitAccessory<OutletDeviceData> {
   static readonly ON = 1;
   static readonly OFF = 0;
@@ -29,6 +35,7 @@ export class Outlet extends ComelitAccessory<OutletDeviceData> {
     const Characteristic = this.platform.Characteristic;
     const status = parseInt(data.status);
     this.outletService.getCharacteristic(Characteristic.On).updateValue(status > 0);
+    plugStatus.set({ plug_name: data.descrizione }, status);
     const power = parseFloat(data.instant_power);
     this.outletService.getCharacteristic(Characteristic.InUse).updateValue(power > 0);
     singleConsumption.set({ plug_name: data.descrizione }, power);

--- a/src/accessories/power-supplier.ts
+++ b/src/accessories/power-supplier.ts
@@ -14,6 +14,7 @@ import { FakegatoHistoryService } from '../types';
 const consumption = new client.Gauge({
   name: 'comelit_total_consumption',
   help: 'Consumption in Wh',
+  labelNames: ['power_meter_name'],
 });
 
 export class PowerSupplier extends ComelitAccessory<SupplierDeviceData> {
@@ -58,7 +59,7 @@ export class PowerSupplier extends ComelitAccessory<SupplierDeviceData> {
   update(data: SupplierDeviceData): void {
     const instantPower = parseFloat(data.instant_power);
     this.log.info(`Reporting instant consumption of ${instantPower}Wh`);
-    consumption.set(instantPower);
+    consumption.set({ power_meter_name: data.descrizione }, instantPower);
 
     this.outletService.updateCharacteristic(
       this.platform.homebridge.hap.Characteristic.OutletInUse,


### PR DESCRIPTION
This PR adds a new `power_meter_name` label to the prometheus metric comelit_total_consumption. This allows people to scope queries for a particular power meter